### PR TITLE
Prevent shooting before spawning

### DIFF
--- a/scripts/Game.js
+++ b/scripts/Game.js
@@ -313,6 +313,7 @@ class Game extends Phaser.Scene {
 
             this.player.x = spawnX;
             this.player.y = spawnY;
+			this.player.canshoot = true;
             this.add.existing(this.player);
             this.gameRunning = true; //player is active so game may run
         }, [], this);

--- a/scripts/Player.js
+++ b/scripts/Player.js
@@ -4,6 +4,7 @@ class Player extends Phaser.Physics.Arcade.Sprite {
         this.scene.events.on('update', this.update, this);
         this.lifetime = 0;
         this.cooldown = 0; //shoot cooldown
+		this.canshoot = false;
     }
 
     spawn(){
@@ -17,7 +18,7 @@ class Player extends Phaser.Physics.Arcade.Sprite {
         if(this.input === undefined || this.input === null) return;
         
         //Attack
-        if(Phaser.Input.Keyboard.JustDown(this.input.attack) && this.cooldown <= 0){
+        if(Phaser.Input.Keyboard.JustDown(this.input.attack) && this.cooldown <= 0 && this.canshoot){
             if(this.anims.currentAnim.key !== 'attack') this.play('attack');
             var proj = this.scene.projectiles.get(this.x, this.y, 0);
             if(proj !== null){


### PR DESCRIPTION
This small fix prevents the player from shooting before they land from their bubble. This would not have any impact on gameplay but it just doesn't look right the way it used to behave.

Old behaviour:
![](https://cdn.discordapp.com/attachments/127410902797385728/506559578901839873/2018-10-29_21-06-31.gif)